### PR TITLE
feat: integrate Hono as API router for Better Auth

### DIFF
--- a/app/api/[...route]/route.ts
+++ b/app/api/[...route]/route.ts
@@ -1,0 +1,14 @@
+import { app } from "@/server"
+import { NextRequest } from "next/server"
+
+const handler = (req: NextRequest) => {
+  return app.fetch(req)
+}
+
+export {
+  handler as GET,
+  handler as POST,
+  handler as PUT,
+  handler as DELETE,
+  handler as PATCH,
+}

--- a/app/api/auth/[...all]/route.ts
+++ b/app/api/auth/[...all]/route.ts
@@ -1,4 +1,0 @@
-import { auth } from "@/lib/auth"
-import { toNextJsHandler } from "better-auth/next-js"
-
-export const { POST, GET } = toNextJsHandler(auth)

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -9,4 +9,7 @@ export const auth = betterAuth({
   emailAndPassword: {
     enabled: true,
   },
+  baseURL: process.env.BETTER_AUTH_URL || "http://localhost:3000",
+  secret: process.env.BETTER_AUTH_SECRET,
+  basePath: "/api/auth",
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@hono/node-server": "^1.19.0",
         "@prisma/client": "^6.11.1",
         "@prisma/extension-accelerate": "^2.0.2",
         "@radix-ui/react-label": "^2.1.7",
@@ -16,6 +17,7 @@
         "better-auth": "^1.2.12",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "hono": "^4.9.2",
         "lucide-react": "^0.525.0",
         "next": "15.3.5",
         "next-themes": "^0.4.6",
@@ -1183,6 +1185,18 @@
       "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
       "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
       "license": "MIT"
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.0.tgz",
+      "integrity": "sha512-1k8/8OHf5VIymJEcJyVksFpT+AQ5euY0VA5hUkCnlKpD4mr8FSbvXaHblxeTTEr90OaqWzAkQaqD80qHZQKxBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -5954,6 +5968,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.9.2.tgz",
+      "integrity": "sha512-UG2jXGS/gkLH42l/1uROnwXpkjvvxkl3kpopL3LBo27NuaDPI6xHNfuUSilIHcrBkPfl4y0z6y2ByI455TjNRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/html-encoding-sniffer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@hono/node-server": "^1.19.0",
         "@prisma/client": "^6.11.1",
         "@prisma/extension-accelerate": "^2.0.2",
         "@radix-ui/react-label": "^2.1.7",
@@ -1185,18 +1184,6 @@
       "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
       "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
       "license": "MIT"
-    },
-    "node_modules/@hono/node-server": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.0.tgz",
-      "integrity": "sha512-1k8/8OHf5VIymJEcJyVksFpT+AQ5euY0VA5hUkCnlKpD4mr8FSbvXaHblxeTTEr90OaqWzAkQaqD80qHZQKxBA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
-      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@hono/node-server": "^1.19.0",
     "@prisma/client": "^6.11.1",
     "@prisma/extension-accelerate": "^2.0.2",
     "@radix-ui/react-label": "^2.1.7",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@hono/node-server": "^1.19.0",
     "@prisma/client": "^6.11.1",
     "@prisma/extension-accelerate": "^2.0.2",
     "@radix-ui/react-label": "^2.1.7",
@@ -27,6 +28,7 @@
     "better-auth": "^1.2.12",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "hono": "^4.9.2",
     "lucide-react": "^0.525.0",
     "next": "15.3.5",
     "next-themes": "^0.4.6",

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,50 @@
+import { Hono } from "hono"
+import { auth } from "@/lib/auth"
+
+// Create API app with base path
+export const app = new Hono<{
+  Variables: {
+    user: typeof auth.$Infer.Session.user | null
+    session: typeof auth.$Infer.Session.session | null
+  }
+}>().basePath("/api")
+
+// Global middleware to add session and user to context
+app.use("*", async (c, next) => {
+  const session = await auth.api.getSession({ headers: c.req.raw.headers })
+
+  if (!session) {
+    c.set("user", null)
+    c.set("session", null)
+    return next()
+  }
+
+  c.set("user", session.user)
+  c.set("session", session.session)
+  return next()
+})
+
+// Mount Better Auth handler
+app.on(["POST", "GET"], "/auth/*", c => {
+  return auth.handler(c.req.raw)
+})
+
+// Example protected route
+app.get("/session", c => {
+  const session = c.get("session")
+  const user = c.get("user")
+
+  if (!user) return c.body(null, 401)
+
+  return c.json({
+    session,
+    user,
+  })
+})
+
+// Health check endpoint
+app.get("/health", c => {
+  return c.json({ status: "ok", timestamp: new Date().toISOString() })
+})
+
+export default app


### PR DESCRIPTION
- Install Hono and @hono/node-server packages
- Create Hono app with proper basePath configuration for API routes
- Replace Next.js API routes with catch-all route that forwards to Hono
- Migrate Better Auth integration from Next.js handler to Hono
- Update Better Auth config with basePath for proper routing
- Add session middleware for automatic user/session context
- Include health check and session endpoints for testing

All authentication flows remain functional while now routing through Hono for better API organization and middleware capabilities.

🤖 Generated with [Claude Code](https://claude.ai/code)